### PR TITLE
Add Phishing Reporter Plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ See also [awesome-pentest § Social Engineering Tools](https://github.com/fabaca
 
 - [CertSpotter](https://github.com/SSLMate/certspotter) - Certificate Transparency log monitor from SSLMate that alerts you when a SSL/TLS certificate is issued for one of your domains.
 - [Gophish](https://getgophish.com/) - Powerful, open-source phishing framework that makes it easy to test your organization's exposure to phishing.
+- [Phishing Reporter](https://github.com/0dteam/Phishing-Reporter) - An Outlook Plugin to report phishing emails easier. It has full integration with GoPhish phishing Framework.
 - [King Phisher](https://github.com/securestate/king-phisher) - Tool for testing and promoting user awareness by simulating real world phishing attacks.
 - [NotifySecurity](https://github.com/certsocietegenerale/NotifySecurity) - Outlook add-in used to help your users to report suspicious e-mails to security teams.
 - [Phishing Intelligence Engine (PIE)](https://github.com/LogRhythm-Labs/PIE) - Framework that will assist with the detection and response to phishing attacks.


### PR DESCRIPTION
An outlook plugin that helps users report phishing emails easier. It also enables integration with GoPhish phishing framework.