### PR TITLE
Add Phish.Report - a web tool to easily report phishing to multiple blocklists

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,7 @@ See also [awesome-pentest § Social Engineering Tools](https://github.com/fabaca
 - [Gophish](https://getgophish.com/) - Powerful, open-source phishing framework that makes it easy to test your organization's exposure to phishing.
 - [King Phisher](https://github.com/securestate/king-phisher) - Tool for testing and promoting user awareness by simulating real world phishing attacks.
 - [NotifySecurity](https://github.com/certsocietegenerale/NotifySecurity) - Outlook add-in used to help your users to report suspicious e-mails to security teams.
+- [Phish.Report](https://phish.report) - Report phishing sites to both the host and multiple blocklist providers from a single tool.
 - [Phishing Intelligence Engine (PIE)](https://github.com/LogRhythm-Labs/PIE) - Framework that will assist with the detection and response to phishing attacks.
 - [Swordphish](https://github.com/certsocietegenerale/swordphish-awareness) - Platform allowing to create and manage (fake) phishing campaigns intended to train people in identifying suspicious mails. 
 - [mailspoof](https://github.com/serain/mailspoof) - Scans SPF and DMARC records for issues that could allow email spoofing.


### PR DESCRIPTION
(Full disclaimer: I wrote and maintain [Phish.Report](https://phish.report))

Although there's already a tool here to help users report phishing to there security team, there isn't one for helping the security team get the phishing site taken down.

This is where Phish.Report can help: it aggregates and automates submission of phishing URLs to both the hosting providers as well as blocklists e.g. Google SafeBrowsing