### PR TITLE
Add CrowdSec Blocklist Import to Threat Intelligence

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,6 +401,7 @@ See also [awesome-threat-detection](https://github.com/0x4D31/awesome-threat-det
 See also [awesome-threat-intelligence](https://github.com/hslatman/awesome-threat-intelligence).
 
 - [AttackerKB](https://attackerkb.com/) - Free and public crowdsourced vulnerability assessment platform to help prioritize high-risk patch application and combat vulnerability fatigue.
+- [CrowdSec Blocklist Import](https://github.com/wolffcatskyy/crowdsec-blocklist-import) - Imports threat intelligence from 36 free public blocklists (FireHOL, Spamhaus, abuse.ch, Emerging Threats, and more) into CrowdSec, aggregating 120,000+ malicious IPs for use with any CrowdSec bouncer.
 - [DATA](https://github.com/hadojae/DATA) - Credential phish analysis and automation tool that can accept suspected phishing URLs directly or trigger on observed network traffic containing such a URL.
 - [Forager](https://github.com/opensourcesec/Forager) - Multi-threaded threat intelligence gathering built with Python3 featuring simple text-based configuration and data storage for ease of use and data portability.
 - [GRASSMARLIN](https://github.com/nsacyber/GRASSMARLIN) - Provides IP network situational awareness of industrial control systems (ICS) and Supervisory Control and Data Acquisition (SCADA) by passively mapping, accounting for, and reporting on your ICS/SCADA network topology and endpoints.


### PR DESCRIPTION
Adds [CrowdSec Blocklist Import](https://github.com/wolffcatskyy/crowdsec-blocklist-import) to the Threat intelligence section, in alphabetical order.

**About the project:**
- Imports threat intelligence from 36 free public blocklists into CrowdSec (FireHOL, Spamhaus, abuse.ch, Emerging Threats, and more)
- Aggregates 120,000+ malicious IPs for use with any CrowdSec bouncer
- Docker-ready with Prometheus metrics and scheduled updates
- 180 stars, MIT licensed