### PR TITLE
Add CrowdSec UniFi Bouncer to Network Perimeter Defenses

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,7 @@ See also [Security Orchestration, Automation, and Response (SOAR)](#security-orc
 
 ## Network perimeter defenses
 
+- [CrowdSec UniFi Bouncer](https://github.com/wolffcatskyy/crowdsec-unifi-bouncer) - CrowdSec bouncer for Ubiquiti UniFi firewalls (UDM, UDM SE, UDR) that persists through firmware updates, with optional AbuseIPDB reporting and Prometheus metrics.
 - [Gatekeeper](https://github.com/AltraMayor/gatekeeper) - First open source Distributed Denial of Service (DDoS) protection system.
 - [fwknop](https://www.cipherdyne.org/fwknop/) - Protects ports via Single Packet Authorization in your firewall.
 - [ssh-audit](https://github.com/jtesta/ssh-audit) - Simple tool that makes quick recommendations for improving an SSH server's security posture.


### PR DESCRIPTION
Adds [CrowdSec UniFi Bouncer](https://github.com/wolffcatskyy/crowdsec-unifi-bouncer) to the Network perimeter defenses section, in alphabetical order.

**About the project:**
- CrowdSec bouncer purpose-built for Ubiquiti UniFi firewalls (UDM, UDM SE, UDR)
- Persists firewall rules through UniFi firmware updates via automatic recovery
- Available as a Go sidecar container or shell-based installer
- Optional AbuseIPDB reporting and Prometheus metrics
- 22 stars, MIT licensed