### PR TITLE
Add Greywall to Host-based tools / Sandboxes

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ See also [awesome-honeypots](https://github.com/paralax/awesome-honeypots).
 - [Bubblewrap](https://github.com/containers/bubblewrap) - Sandboxing tool for use by unprivileged Linux users capable of restricting access to parts of the operating system or user data.
 - [Dangerzone](https://dangerzone.rocks/) - Take potentially dangerous PDFs, office documents, or images and convert them to a safe PDF.
 - [Firejail](https://firejail.wordpress.com/) - SUID program that reduces the risk of security breaches by restricting the running environment of untrusted applications using Linux namespaces and seccomp-bpf.
+- [Greywall](https://github.com/GreyhavenHQ/greywall) - Deny-by-default command sandbox for AI coding agents and CLI tools, providing filesystem and network isolation using bubblewrap, seccomp, and Landlock on Linux and Seatbelt profiles on macOS, with built-in profiles for agents like Claude Code or OpenCode.
 
 ## Identity and AuthN/AuthZ
 


### PR DESCRIPTION
Add [Greywall](https://github.com/GreyhavenHQ/greywall) to the Sandboxes subsection under Host-based tools.

Greywall is a deny-by-default command sandbox that wraps CLI commands with restricted filesystem access and transparent network redirection. It uses bubblewrap, seccomp, and Landlock on Linux and sandbox-exec Seatbelt profiles on macOS.