### PR TITLE
Add defend.network to Threat intelligence

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,6 +402,7 @@ See also [awesome-threat-intelligence](https://github.com/hslatman/awesome-threa
 
 - [AttackerKB](https://attackerkb.com/) - Free and public crowdsourced vulnerability assessment platform to help prioritize high-risk patch application and combat vulnerability fatigue.
 - [DATA](https://github.com/hadojae/DATA) - Credential phish analysis and automation tool that can accept suspected phishing URLs directly or trigger on observed network traffic containing such a URL.
+- [defend.network](https://defend.network) - Free AI-powered daily threat briefings and weekly vulnerability reports structured by threat type, industry, and severity, with action checklists and remediation guidance for security teams.
 - [Forager](https://github.com/opensourcesec/Forager) - Multi-threaded threat intelligence gathering built with Python3 featuring simple text-based configuration and data storage for ease of use and data portability.
 - [GRASSMARLIN](https://github.com/nsacyber/GRASSMARLIN) - Provides IP network situational awareness of industrial control systems (ICS) and Supervisory Control and Data Acquisition (SCADA) by passively mapping, accounting for, and reporting on your ICS/SCADA network topology and endpoints.
 - [MLSec Combine](https://github.com/mlsecproject/combine) - Gather and combine multiple threat intelligence feed sources into one customizable, standardized CSV-based format.


### PR DESCRIPTION
Add defend.network to Threat intelligence

defend.network publishes free daily AI-generated threat briefings and weekly vulnerability reports for security teams.

Each briefing is structured by threat type (16 categories), affected industry (13 categories), and severity level, with specific action checklists and remediation guidance.

Sources include CISA advisories, vendor bulletins, and leading cybersecurity publications including The Hacker News, BleepingComputer, Krebs on Security, Dark Reading, and The Record.

- Completely free, no signup required
- RSS feed available at https://defend.network/feed.xml
- 29 category pages for browsing by threat type or industry
- Weekly vulnerability reports with patch priority matrices

https://defend.network